### PR TITLE
sync.sh: fix git config on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ This will do the following:
 - SSH into the machine and create a folder in `$ROOT` for each
   repository/submodule in this repo.
 - Run `git init --bare` for each of the above repositories.
-- Run `git config --global url."<root>".insteadOf 'git@github.com:'`. This means
-  that every pull/push/fetch on that machine to a GitHub repository will now
-  reference the locally bare repositories instead.
+- Run `git config --global --replace-all url."$ROOT".insteadOf 'git@github.com:'`.
+  This means that every pull/push/fetch on that machine to a GitHub repository
+  will now reference the locally bare repositories instead.
+- Run `git config --global --replace-all url."git@github.com:".insteadOf 'https://github.com/'`.
+  This allows for HTTPS repositories to get the same treatment as SSH
+  repositories.
 
 #### `push`
 

--- a/sync.sh
+++ b/sync.sh
@@ -193,11 +193,12 @@ if [[ "${COMMAND}" == "init" ]]; then
       done
 
       # Configure all git repositories to point to the local bare repositories.
+      # NOTE: Order matters.
       pushd \"${ROOT}\"
       git config --global --replace-all \
-        url.\"\${PWD}/\".insteadOf 'git@github.com:'
+        url.\"git@github.com:\".insteadOf 'https://github.com/'
       git config --global --replace-all \
-        url.\"\${PWD}/\".insteadOf 'https://github.com/'
+        url.\"\${PWD}/\".insteadOf 'git@github.com:'
       popd
     "
     echo


### PR DESCRIPTION
We can only have one `url."$ROOT".insteadOf` at a time, so we chain 2 replacements together to get the desired effect.