### PR TITLE
Add shellcheck directives to source

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -4,6 +4,8 @@
 #
 # Formats all Python and C++ code in the repository with YAPF and clang-format.
 #
+# shellcheck disable=SC2086
+#
 
 # Default arguments.
 DRY_RUN=false
@@ -223,13 +225,13 @@ if [[ ${CHANGES_ONLY} == "true" ]]; then
   )"
 elif [[ -z "${PACKAGE}" ]]; then
   CLANG_FORMAT_FILES="$(
-    eval "find ${DIR}/catkin_ws/src \( \
+    eval "find ${DIR}/catkin_ws/src \\( \
         -iname '*.h' -o \
         -iname '*.c' -o \
         -iname '*.cpp' -o \
         -iname '*.hpp' -o \
         -iname '*.ino' \
-      \) -and ${FIND_EXCLUDES}"
+      \\) -and ${FIND_EXCLUDES}"
   )"
 else
   # Don't exclude any submodules if a package was specified.

--- a/lint.sh
+++ b/lint.sh
@@ -5,6 +5,8 @@
 # Lints the current repository with catkin_lint while ignoring submodules and
 # any errors defined in a .lintignore file at the root of the repository.
 #
+# shellcheck disable=SC2010,SC2086
+#
 
 # Exit on first error.
 set -e

--- a/sync.sh
+++ b/sync.sh
@@ -5,6 +5,8 @@
 # Syncs the repository and its submodules with any machine on the local area
 # network that is accessible by SSH.
 #
+# shellcheck disable=SC2029,SC2086
+#
 
 # Exit on first error.
 set -e

--- a/update_repo.sh
+++ b/update_repo.sh
@@ -48,7 +48,7 @@ if [[ -z "$(git status -s)" ]]; then
       echo "Updating automatically will lose any local changes in ${DIR})"
       echo -n "${QUESTION}Do you wish to hard reset to remote?${RESET}"
       echo -n " [y/N] (default no) "
-      read hard_reset
+      read -r hard_reset
       case "${hard_reset}" in
         y|Y )
           echo "${WARNING}Running: git reset --hard ${remote_branch}${RESET}"


### PR DESCRIPTION
We can't remove the `--exclude`s from the `Jenkinsfile` just yet due to some bug in the `shellcheck` version that is packaged in Ubuntu 16.04. For some reason, it seems to be ignoring these directives, but this still nice to have for when we eventually upgrade.